### PR TITLE
Added ability to view, create, and delete subgroups on TeamView

### DIFF
--- a/src/apps/Teams/teams.css
+++ b/src/apps/Teams/teams.css
@@ -16,5 +16,14 @@
     justify-content: flex-start;
     align-items: center;
     padding: 8px 0px 8px 16px;
-    list-style:
+    /* list-style: */
+}
+
+.deleteIcon {
+    margin-right: 10%;
+    margin-top: 3px;
+}
+
+.deleteIcon:hover, .addIcon:hover {
+    cursor: pointer;
 }


### PR DESCRIPTION
Groups widget on TeamView now displays the subgroups of a team. Users can delete existing subgroups or add new ones. No further functionality exists at this time -- more on this Post MVP